### PR TITLE
チャイムの除外日設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 .DS_Store*
 .hubot_history
 
+gooAPIkey.txt
 chime_ignore.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .DS_Store*
 .hubot_history
+
+chime_ignore.txt

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "hubot-scripts": "^2.16.2",
     "hubot-shipit": "^0.2.0",
     "hubot-slack": "^3.4.2",
+    "request": "^2.79.0",
     "time": "^0.11.4"
   },
   "engines": {

--- a/scripts/chime.coffee
+++ b/scripts/chime.coffee
@@ -3,43 +3,56 @@
 #
 # Notes:
 #   cronモジュール使います
-#   
+#
 
 cron = require('cron').CronJob
+fs = require('fs')
+
+settingFile = "./chime_ignore.txt"
+
+chime = (message) ->
+  fs.readFile settingFile, 'utf8', (err, text) ->
+    if text
+      ignoreList = text.split('\n')
+    else
+      ignoreList = []
+
+    today = do (do new Date).toDateString
+    if ignoreList.indexOf today == -1
+      robot.send {room: "#chime"}, message
 
 module.exports = (robot) ->
 
 # 水曜日
   new cron '00 15 12 * * 3', () =>
-    robot.send {room: "#chime"}, "授業始まるぞ！！！"
+    chime "授業始まるぞ！！！"
   , null, true, "Asia/Tokyo"
 
   new cron '00 30 13 * * 3', () =>
-    robot.send {room: "#chime"}, "休憩だぞ！！！"
+    chime "休憩だぞ！！！"
   , null, true, "Asia/Tokyo"
 
   new cron '00 45 13 * * 3', () =>
-    robot.send {room: "#chime"}, "休憩終わりだぞ！！！"
+    chime "休憩終わりだぞ！！！"
   , null, true, "Asia/Tokyo"
 
   new cron '00 00 15 * * 3', () =>
-    robot.send {room: "#chime"}, "授業終わりだぞ！！！"
+    chime "授業終わりだぞ！！！"
   , null, true, "Asia/Tokyo"
 
 # 金曜日
   new cron '00 15 15 * * 5', () =>
-    robot.send {room: "#chime"}, "授業始まるぞ！！！"
+    chime "授業始まるぞ！！！"
   , null, true, "Asia/Tokyo"
 
   new cron '00 30 16 * * 5', () =>
-    robot.send {room: "#chime"}, "休憩だぞ！！！"
+    chime "休憩だぞ！！！"
   , null, true, "Asia/Tokyo"
 
   new cron '00 45 16 * * 5', () =>
-    robot.send {room: "#chime"}, "休憩終わりだぞ！！！"
+    chime "休憩終わりだぞ！！！"
   , null, true, "Asia/Tokyo"
 
   new cron '00 00 18 * * 5', () =>
-    robot.send {room: "#chime"}, "授業終わりだぞ！！！"
+    chime "授業終わりだぞ！！！"
   , null, true, "Asia/Tokyo"
-  

--- a/scripts/chime_manager.coffee
+++ b/scripts/chime_manager.coffee
@@ -7,7 +7,7 @@
 request = require('request')
 fs = require('fs')
 
-gooApiId = ""
+gooApiId = fs.readFileSync 'gooAPIkey.txt', 'utf8'
 
 settingFile = "./chime_ignore.txt"
 

--- a/scripts/chime_manager.coffee
+++ b/scripts/chime_manager.coffee
@@ -7,7 +7,7 @@
 request = require('request')
 fs = require('fs')
 
-gooApiId = "af16a8680f3a471ea78c5f709e1dde351d2a4711953deaf518abb9962db443c4"
+gooApiId = ""
 
 settingFile = "./chime_ignore.txt"
 

--- a/scripts/chime_manager.coffee
+++ b/scripts/chime_manager.coffee
@@ -21,7 +21,7 @@ module.exports = (robot) ->
       headers: { "Content-type": "application/json" },
       json: {
         "app_id": gooApiId,
-        "sentence": msg.match[1]
+        "sentence": msg.match[0]
       }
     }
 
@@ -54,7 +54,7 @@ module.exports = (robot) ->
       headers: { "Content-type": "application/json" },
       json: {
         "app_id": gooApiId,
-        "sentence": msg.match[1]
+        "sentence": msg.match[0]
       }
     }
 

--- a/scripts/chime_manager.coffee
+++ b/scripts/chime_manager.coffee
@@ -1,0 +1,82 @@
+# Description:
+#   チャイムを制御します
+#
+# Notes:
+#
+
+request = require('request')
+fs = require('fs')
+
+gooApiId = "af16a8680f3a471ea78c5f709e1dde351d2a4711953deaf518abb9962db443c4"
+
+settingFile = "./chime_ignore.txt"
+
+toLocaleDateString = (date) ->
+  "#{do date.getFullYear}年#{do date.getMonth + 1}月#{do date.getDate}日"
+
+module.exports = (robot) ->
+  robot.hear /(.*)(鳴らす|ならす|鳴らし|ならし).*/i, (msg) ->
+    options = {
+      uri: "https://labs.goo.ne.jp/api/chrono",
+      headers: { "Content-type": "application/json" },
+      json: {
+        "app_id": gooApiId,
+        "sentence": msg.match[1]
+      }
+    }
+
+    request.post options, (error, response, body) ->
+      targetDate = new Date (do body.datetime_list.toString).split(",")[1]
+      targetDateString = toLocaleDateString targetDate
+
+      fs.readFile settingFile, 'utf8', (err, text) ->
+        if text
+          ignoreList = text.split('\n')
+        else
+          ignoreList = []
+
+        if body.datetime_list.length != 0
+          if ignoreList.indexOf(do targetDate.toDateString) != -1
+            ignoreList.pop ignoreList.indexOf(do targetDate.toDateString)
+            fs.writeFile settingFile, ignoreList.join('\n'), (err) ->
+              if err
+                msg.send err
+              else
+                msg.send "#{targetDateString} のチャイムを設定しました"
+          else
+            msg.send "#{targetDateString} のチャイムは既に設定されています"
+        else
+          msg.send "日付情報が取得できません"
+
+  robot.hear /(.*)(鳴らさない|ならさない|止め|とめ).*/i, (msg) ->
+    options = {
+      uri: "https://labs.goo.ne.jp/api/chrono",
+      headers: { "Content-type": "application/json" },
+      json: {
+        "app_id": gooApiId,
+        "sentence": msg.match[1]
+      }
+    }
+
+    request.post options, (error, response, body) ->
+      targetDate = new Date (do body.datetime_list.toString).split(",")[1]
+      targetDateString = toLocaleDateString targetDate
+
+      fs.readFile settingFile, 'utf8', (err, text) ->
+        if text
+          ignoreList = text.split('\n')
+        else
+          ignoreList = []
+
+        if body.datetime_list.length != 0
+          if ignoreList.indexOf(do targetDate.toDateString) == -1
+            ignoreList.push (do targetDate.toDateString)
+            fs.writeFile settingFile, ignoreList.join('\n'), (err) ->
+              if err
+                msg.send err
+              else
+                msg.send "#{targetDateString} のチャイムを解除しました"
+          else
+            msg.send "#{targetDateString} のチャイムは既に解除されています"
+        else
+          msg.send "日付情報が取得できません"


### PR DESCRIPTION
#2 を解決するためのPR

本当にチャイムが鳴らなくなるかは未検証です。

実行するためには、[gooラボAPI](https://labs.goo.ne.jp/apiusage/) のIDを取得し、chime_manager.coffee に設定する必要があります。